### PR TITLE
[G-27] 500 페이지 구현

### DIFF
--- a/src/page-components/home/index.test.tsx
+++ b/src/page-components/home/index.test.tsx
@@ -10,53 +10,55 @@ import POSTS from '@/fixture/posts';
 
 // 💡 TODO-GYU: E2E 테스트
 // ❓ 굳이 해당 테스트가 필요한가 궁금!
-// 렌더링 테스트만 하고 cypress 에서 E2E 테스트 할 예정describe('HomePage', () => {
-const dispatch = jest.fn();
-beforeEach(() => {
-  dispatch.mockClear();
+// 렌더링 테스트만 하고 cypress 에서 E2E 테스트 할 예정
+describe('HomePage', () => {
+  const dispatch = jest.fn();
+  beforeEach(() => {
+    dispatch.mockClear();
 
-  jest.spyOn(redux, 'useDispatch').mockImplementation(() => dispatch);
-  jest.spyOn(redux, 'useSelector').mockImplementation((selector) =>
-    selector({
-      selectedTag: given.selectedTag,
-    }),
-  );
-});
-
-describe('렌더링 테스트', () => {
-  given('selectedTag', () => '#전체보기');
-
-  it('태그들을 렌더링한다', () => {
-    const tags = [
-      { id: '1', name: 'all' },
-      { id: '2', name: '리액트' },
-      { id: '3', name: '바닐라' },
-      { id: '4', name: '개발환경' },
-    ];
-
-    const { container } = render(<HomePage tags={tags} posts={POSTS} />);
-
-    tags.forEach((tag) => {
-      expect(container).toHaveTextContent(`#${tag.name}`);
-    });
+    jest.spyOn(redux, 'useDispatch').mockImplementation(() => dispatch);
+    jest.spyOn(redux, 'useSelector').mockImplementation((selector) =>
+      selector({
+        selectedTag: given.selectedTag,
+      }),
+    );
   });
 
-  it('게시물들을 렌더링한다', () => {
-    const tags = [
-      { id: '1', name: 'all' },
-      { id: '2', name: '리액트' },
-      { id: '3', name: '바닐라' },
-      { id: '4', name: '개발환경' },
-    ];
+  describe('렌더링 테스트', () => {
+    given('selectedTag', () => '#전체보기');
 
-    const { container } = render(<HomePage tags={tags} posts={POSTS} />);
+    it('태그들을 렌더링한다', () => {
+      const tags = [
+        { id: '1', name: 'all' },
+        { id: '2', name: '리액트' },
+        { id: '3', name: '바닐라' },
+        { id: '4', name: '개발환경' },
+      ];
 
-    POSTS.forEach((post) => {
-      expect(container).toHaveTextContent(post.title);
-      expect(container).toHaveTextContent(post.createdTime);
-      expect(container).toHaveTextContent(post.description);
-      post.tags.map((tag) => {
+      const { container } = render(<HomePage tags={tags} posts={POSTS} />);
+
+      tags.forEach((tag) => {
         expect(container).toHaveTextContent(`#${tag.name}`);
+      });
+    });
+
+    it('게시물들을 렌더링한다', () => {
+      const tags = [
+        { id: '1', name: 'all' },
+        { id: '2', name: '리액트' },
+        { id: '3', name: '바닐라' },
+        { id: '4', name: '개발환경' },
+      ];
+
+      const { container } = render(<HomePage tags={tags} posts={POSTS} />);
+
+      POSTS.forEach((post) => {
+        expect(container).toHaveTextContent(post.title);
+        expect(container).toHaveTextContent(post.createdTime);
+        expect(container).toHaveTextContent(post.description);
+        post.tags.map((tag) => {
+          expect(container).toHaveTextContent(`#${tag.name}`);
+        });
       });
     });
   });

--- a/src/pages/404.page.tsx
+++ b/src/pages/404.page.tsx
@@ -4,7 +4,7 @@ import { NextSeo } from 'next-seo';
 
 import ErrorPage from '@/components/common/Error';
 
-export default function NotFoundPage() {
+export default function Custom404() {
   const router = useRouter();
 
   const handleGoHome = () => router.push('/');

--- a/src/pages/404.test.tsx
+++ b/src/pages/404.test.tsx
@@ -6,13 +6,13 @@ import { NextRouter } from 'next/router';
 
 import { createMockRouter } from '@/src/test-utils/createMockRouter';
 
-import NotFoundPage from './404.page';
+import Custom404 from './404.page';
 
 describe('404 Page', () => {
   function renderComponent(router: NextRouter) {
     return render(
       <RouterContext.Provider value={router}>
-        <NotFoundPage />
+        <Custom404 />
       </RouterContext.Provider>,
     );
   }

--- a/src/pages/500.page.tsx
+++ b/src/pages/500.page.tsx
@@ -1,0 +1,25 @@
+import { useRouter } from 'next/router';
+
+import { NextSeo } from 'next-seo';
+
+import ErrorPage from '@/components/common/Error';
+
+export default function Custom500() {
+  const router = useRouter();
+
+  const handleGoHome = () => router.push('/');
+
+  return (
+    <>
+      <NextSeo
+        title="SEUNGGYU - 500" //
+      />
+      <ErrorPage
+        message="Internal Server Error" //
+        description="🐛 알 수 없는 오류 발생"
+        buttonText="Go To Home"
+        onClick={handleGoHome}
+      />
+    </>
+  );
+}

--- a/src/pages/500.test.tsx
+++ b/src/pages/500.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent } from '@/src/test-utils/test-utils';
+
+import { RouterContext } from 'next/dist/shared/lib/router-context';
+
+import { NextRouter } from 'next/router';
+
+import { createMockRouter } from '@/src/test-utils/createMockRouter';
+
+import Custom500 from './500.page';
+
+describe('500 Page', () => {
+  function renderComponent(router: NextRouter) {
+    return render(
+      <RouterContext.Provider value={router}>
+        <Custom500 />
+      </RouterContext.Provider>,
+    );
+  }
+
+  // GYU: 현재는 getStaticProps 로 SSG 로 제어해서 build 시 check하기 때문에 현재는 500 page 나올 가능성 없음
+  describe('Server Side 에러가 발생하면 ', () => {
+    it('500 페이지를 렌더링한다.', () => {
+      const router = createMockRouter({ asPath: '/' });
+      renderComponent(router);
+
+      expect(screen.getByTestId('error-page-main-image')).toBeInTheDocument();
+      expect(screen.getByText('Internal Server Error')).toBeInTheDocument();
+      expect(screen.getByText('🐛 알 수 없는 오류 발생')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Go To Home' })).toBeInTheDocument();
+    });
+  });
+
+  describe('버튼을 클릭하면', () => {
+    const router = createMockRouter({ asPath: '/temp' });
+
+    it('홈으로 이동한다.', () => {
+      renderComponent(router);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Go To Home' }));
+
+      expect(router.push).toBeCalledWith('/');
+    });
+  });
+});


### PR DESCRIPTION
## ✨ 주요 변경사항
- [x] 500 에러 페이지 구현
- [x] 500 에러 페이지 테스트

--- 
- 현재 서비스에는 Server Side Error 가 나올 상황이 존재하지 않아, 500 e2e 테스트 작성하지 않음.   
  추후에 그런 상황이 오면 추가할 예정


## 🔗 참고자료
- [nextjs 와 cypress 테스트 방법 참고](https://glebbahmutov.com/blog/control-nextjs-data-during-tests/)

close #64 