### PR TITLE
feat : notion cms 관리 방식 변경

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -3,6 +3,7 @@ import notionApi from './notion-api/client';
 
 import { Post, MultiSelectType } from '@/types/index';
 import { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+import { HOME_POSTS_DATABASE_ID } from '@/src/constant';
 
 export async function getDetailPost(postId: string) {
   const [recordMap, postPage]: any = await Promise.all([notionApi.getPage(postId), notionClient.getPage(postId)]);
@@ -89,4 +90,22 @@ export async function getPosts(rootPostId: string) {
     });
 
   return posts;
+}
+
+export async function getPostItemByTitle(title: string) {
+  const response = await notionClient.getDatabaseItem({
+    database_id: HOME_POSTS_DATABASE_ID,
+    filter: {
+      property: 'title',
+      rich_text: {
+        contains: title.replaceAll('-', ' '),
+      },
+    },
+  });
+
+  if (!response.results.length) {
+    return null;
+  }
+
+  return response.results[0];
 }

--- a/src/components/PostItem/index.tsx
+++ b/src/components/PostItem/index.tsx
@@ -15,13 +15,7 @@ export default function PostItem({ post }: Props) {
 
   return (
     <S.PostItem>
-      <Link
-        href={{
-          pathname: `/posts/${post.id}`,
-          query: { post: JSON.stringify(post) },
-        }}
-        as={`/posts/${post.id}`}
-      >
+      <Link href={`/posts/${title.trim().replaceAll(' ', '-')}`}>
         <a>
           <div>
             <S.Title>{title}</S.Title>

--- a/src/pages/posts/[title].page.tsx
+++ b/src/pages/posts/[title].page.tsx
@@ -6,9 +6,10 @@ import PostPage from '@/page-components/post';
 
 import { HOME_POSTS_DATABASE_ID } from 'src/constant';
 
-import { getPosts, getDetailPost } from '@/src/apis';
+import { getPosts, getDetailPost, getPostItemByTitle } from '@/src/apis';
 
 import { Post } from '@/types/index';
+import * as notionClient from '@/src/apis/notion-client';
 
 type Props = {
   recordMap: any;
@@ -52,17 +53,21 @@ export const getStaticPaths = async () => {
   const posts = await getPosts(postsDatabaseId);
 
   const paths = posts.map((post: Post) => ({
-    params: { id: post.id },
+    params: { title: post.title },
   }));
 
   return { paths, fallback: 'blocking' };
 };
 
 export async function getStaticProps({ params }: any) {
-  const postId = params.id;
+  const postId = params.title;
 
-  const { recordMap, post } = await getDetailPost(postId);
+  const result = await getPostItemByTitle(postId);
+  if (!result) {
+    return { props: {} };
+  }
 
+  const { recordMap, post } = await getDetailPost(result.id);
   return {
     props: {
       recordMap,


### PR DESCRIPTION
close #86 

## 💡 개요
- 현재 노션을 이용해서 블로그 컨텐츠를 이용하는데 블로그에서 상태를 둬서 배포 상태인것만 배포되도록 변경하기
- 블로그 page 를 렌더링할 때 hash-id 가 url 로 가는데 타이틀로 하도록 변경하기 (또는 slug 로 표현하기

## 📝 작업 내용 또는 주요 변경 사항
<img width="1549" alt="image" src="https://github.com/KIMSEUNGGYU/blog/assets/45627868/1f02c639-976a-4909-8c08-cc068808ddcd">
- teompory (임시 글) 상태를 둬서 체크 안 된 것들만 배포 되도록 변경

- 기존 URL 방식 (해시) 을 title 로 변경 \
![image](https://github.com/KIMSEUNGGYU/blog/assets/45627868/e8d46fa1-7150-4fd6-8d8e-05bb0d22dc43)


## ‼️ 주의 사항
<!-- 해당 작업에서 주의해아할 사항  -->

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->
